### PR TITLE
T8432 - Migração da base de codigo para Python 3.10

### DIFF
--- a/report_py3o/models/py3o_report.py
+++ b/report_py3o/models/py3o_report.py
@@ -295,7 +295,7 @@ class Py3oReport(models.TransientModel):
         attachment = existing_reports_attachment.get(
             model_instance.id)
         if attachment and self.ir_actions_report_id.attachment_use:
-            content = base64.decodestring(attachment.datas)
+            content = base64.decodebytes(attachment.datas)
             report_file = tempfile.mktemp(
                 "." + self.ir_actions_report_id.py3o_filetype)
             with open(report_file, "wb") as f:

--- a/report_qweb_signer/models/ir_actions_report.py
+++ b/report_qweb_signer/models/ir_actions_report.py
@@ -82,7 +82,7 @@ class IrActionsReport(models.Model):
             ('res_id', '=', res_ids[0]),
         ], limit=1)
         if attachment:
-            return base64.decodestring(attachment.datas)
+            return base64.decodebytes(attachment.datas)
         return False
 
     def _attach_signed_write(self, res_ids, certificate, signed):


### PR DESCRIPTION
# Descrição

* Migração para Python 3.10

# Informações adicionais

Dados da tarefa: [T8432](https://multi.multidados.tech/web#id=8841&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): 

* https://github.com/multidadosti-erp/odoo/pull/274

