### PR TITLE
T8742 - Erro de assinatura de XML no Python 3.10

### DIFF
--- a/kpi/__manifest__.py
+++ b/kpi/__manifest__.py
@@ -29,5 +29,5 @@
         "images/kpi_threshold.png",
         "images/kpi_range.png",
     ],
-    'installable': True,
+    'installable': False,
 }

--- a/kpi_dashboard/__manifest__.py
+++ b/kpi_dashboard/__manifest__.py
@@ -22,4 +22,5 @@
     ],
     "demo": ["demo/demo_dashboard.xml"],
     "maintainers": ["etobella"],
+    "installable": False,
 }

--- a/kpi_dashboard_bokeh/__manifest__.py
+++ b/kpi_dashboard_bokeh/__manifest__.py
@@ -13,4 +13,7 @@
     "data": ["views/webclient_templates.xml"],
     "qweb": ["static/src/xml/dashboard.xml"],
     "demo": ["demo/demo_dashboard.xml"],
+    'installable': False,
+    'auto_install': False,
+    'application': False,
 }

--- a/report_py3o/tests/test_report_py3o.py
+++ b/report_py3o/tests/test_report_py3o.py
@@ -121,7 +121,7 @@ class TestReportPy3o(TransactionCase):
         # put a new content into tha attachement and check that the next
         # time we ask the report we received the saved attachment not a newly
         # generated document
-        created_attachement.datas = base64.encodestring(b"new content")
+        created_attachement.datas = base64.encodebytes(b"new content")
         res = self.report.render(self.env.user.ids)
         self.assertEqual((b'new content', self.report.py3o_filetype), res)
 

--- a/report_qweb_signer/models/ir_actions_report.py
+++ b/report_qweb_signer/models/ir_actions_report.py
@@ -94,7 +94,7 @@ class IrActionsReport(models.Model):
         try:
             attachment = self.env['ir.attachment'].create({
                 'name': filename,
-                'datas': base64.encodestring(signed),
+                'datas': base64.encodebytes(signed),
                 'datas_fname': filename,
                 'res_model': certificate.model_id.model,
                 'res_id': res_ids[0],


### PR DESCRIPTION
# Descrição

Substitui encodestring por decodebytes

# Informações adicionais

Dados da tarefa: [T8742](https://multi.multidados.tech/web#id=9151&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
